### PR TITLE
fix: prevent iOS Safari control bar from obscuring footer

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -367,6 +367,7 @@ article > ul li:before {
 footer {
     margin-top: auto;
     padding-top: 2rem;
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
     color: var(--text-color-light);
     font-size: 0.9rem;
     text-align: center;

--- a/src/template.html
+++ b/src/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
         <!-- Title -->
         <title>


### PR DESCRIPTION
- Add viewport-fit=cover to enable safe area insets
- Add bottom padding to footer using env(safe-area-inset-bottom)
- Ensures footer content is always visible above iOS Safari's floating UI